### PR TITLE
Fix theme initialization in ThemeToggle

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -7,8 +7,9 @@ const ThemeToggle = () => {
       ? localStorage.getItem("theme")
       : "light";
 
-  const [theme, setTheme] = useState(getInitialTheme);
-  const [icon, setIcon] = useState(getInitialTheme);
+  // Use lazy initialization to avoid storing the initializer function itself
+  const [theme, setTheme] = useState(() => getInitialTheme());
+  const [icon, setIcon] = useState(() => getInitialTheme());
   const [clicked, setClicked] = useState(false);
   const [hovered, setHovered] = useState(false);
 


### PR DESCRIPTION
## Summary
- fix theme toggle initialization by lazily computing state

## Testing
- `npm run build` *(fails: esbuild binary for wrong platform)*

------
https://chatgpt.com/codex/tasks/task_e_684825f96d5c832f92c4104a1032360d