### PR TITLE
Add work submenu to sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import "./sidebar.css";
 
 export default function Sidebar() {
+  const [showWorkMenu, setShowWorkMenu] = useState(false);
+
   return (
     <aside
       style={{
@@ -18,17 +21,53 @@ export default function Sidebar() {
         paddingLeft: "20px",
       }}
     >
-      <a href="/" className="sidebar-link">work</a>
-<a href="/journal" className="sidebar-link">journal</a>
-<a
-  href="mailto:robert.antonov0@gmail.com"
-  className="sidebar-link"
-  target="_blank"
-  rel="noopener noreferrer"
->
-  contact
-</a>
-
+      <div
+        className="work-container"
+        onMouseEnter={() => setShowWorkMenu(true)}
+        onMouseLeave={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget)) {
+            setShowWorkMenu(false);
+          }
+        }}
+        style={{ position: "relative" }}
+      >
+        <a href="/" className="sidebar-link">
+          work
+        </a>
+        {showWorkMenu && (
+          <div className="work-submenu">
+            <a href="/studio" className="sidebar-sublink">
+              studio
+            </a>
+            <a href="/events" className="sidebar-sublink">
+              events
+            </a>
+            <a href="/corporate" className="sidebar-sublink">
+              corporate
+            </a>
+            <a href="/personal-projects" className="sidebar-sublink">
+              personal projects
+            </a>
+            <a href="/street-snaps" className="sidebar-sublink">
+              street snaps
+            </a>
+            <a href="/film" className="sidebar-sublink">
+              film
+            </a>
+          </div>
+        )}
+      </div>
+      <a href="/journal" className="sidebar-link">
+        journal
+      </a>
+      <a
+        href="mailto:robert.antonov0@gmail.com"
+        className="sidebar-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        contact
+      </a>
     </aside>
   );
 }

--- a/src/components/sidebar.css
+++ b/src/components/sidebar.css
@@ -17,3 +17,23 @@
   transform: translateX(8px);  /* Mută 8px la dreapta */
   padding-left: 0;
 }
+
+.work-submenu {
+  position: absolute;
+  top: 0;
+  left: 60px;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-sublink {
+  color: #fff;
+  font-size: 16px;
+  margin-bottom: 6px;
+  text-decoration: none;
+  transition: color 0.2s cubic-bezier(.66,-0.01,.32,1.01);
+}
+
+.sidebar-sublink:hover {
+  color: #ff4d88;
+}


### PR DESCRIPTION
## Summary
- add React state to show submenu on hover
- include links for additional work options
- style submenu links in sidebar CSS
- fix hover behavior so submenu stays open when moving the mouse to it

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68482a4a7630832fb7c725fed21c250a