### PR TITLE
Fix submenu gap in sidebar

### DIFF
--- a/src/components/sidebar.css
+++ b/src/components/sidebar.css
@@ -21,7 +21,7 @@
 .work-submenu {
   position: absolute;
   top: 0;
-  left: 60px;
+  left: 50px;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- adjust `.work-submenu` left offset so submenu stays open

## Testing
- `npm run build` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68483dd3c8e4832fa442c52f63c98fe3