### PR TITLE
Fix sidebar submenu positioning

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -31,7 +31,11 @@ export default function Sidebar() {
           work
         </a>
         {showWorkMenu && (
-          <div className="work-submenu">
+          <div
+            className="work-submenu"
+            onMouseEnter={() => setShowWorkMenu(true)}
+            onMouseLeave={() => setShowWorkMenu(false)}
+          >
             <a href="/studio" className="sidebar-sublink">
               studio
             </a>

--- a/src/components/sidebar.css
+++ b/src/components/sidebar.css
@@ -18,10 +18,15 @@
   padding-left: 0;
 }
 
+.work-container {
+  display: inline-block;
+  position: relative;
+}
+
 .work-submenu {
   position: absolute;
   top: 0;
-  left: 60px;
+  left: 100%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- tweak sidebar menu style so submenu lines up with work link
- keep submenu visible when moving the pointer between main item and submenu

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483fb599a0832f846b62f8d886cbd9